### PR TITLE
Add custom repeat events to replace holdRepeat

### DIFF
--- a/lib/flixel/addons/input/FlxAnalogSet.hx
+++ b/lib/flixel/addons/input/FlxAnalogSet.hx
@@ -9,6 +9,7 @@ import flixel.input.actions.FlxActionInput;
 import flixel.input.actions.FlxAction;
 import flixel.input.actions.FlxActionInputAnalog;
 import flixel.input.actions.FlxActionSet;
+import flixel.input.gamepad.FlxGamepad;
 import flixel.input.gamepad.FlxGamepadInputID;
 import flixel.input.keyboard.FlxKey;
 import flixel.math.FlxMath;
@@ -61,22 +62,32 @@ abstract FlxAnalogSet1DBase<TAction:EnumValue>(FlxAnalogSet<TAction>) to FlxAnal
      * Helper for extracting digital directional states from a 2D analog action.
      * It is similar to `justPressed` but holding the input for 0.5s will make it fire every 0.1s
      */
-    @:deprecated("holdRepeat is deprecated, use repeat(), instead")
+    @:deprecated("holdRepeat is deprecated, use waitAndRepeat(), instead")
     public var holdRepeat(get, never):FlxAnalogDirections1D<TAction>;
     inline function get_holdRepeat()
     {
-        return repeat(REPEAT_DELAY, INITIAL_DELAY);
+        return waitAndRepeat();
     }
     
     /**
-     * A repeating  event, similar to `justPressed` but holding the
-     * input for some `initial` time will make it fire every repeatedly.
-     * @param repeat   How often to repeat the event
-     * @param initial  How long until the second firing
+     * An event that fires when just pressed, then repeats at the given interval
+     * 
+     * @param   delay  How often to fire the event
      */
-    public function repeat(repeat = 0.1, initial = 0.0):FlxAnalogDirections1D<TAction>
+    inline public function repeat(delay = 0.1):FlxAnalogDirections1D<TAction>
     {
-        return this.getRepeater(repeat, initial);
+        return this.getRepeater(0, delay);
+    }
+    
+    /**
+     * An event that fires when just pressed, then repeats after the initial time
+     * 
+     * @param   initialDelay  How long after the initial press to start repeating
+     * @param   repeatDelay   How often to fire the event
+     */
+    inline public function waitAndRepeat(initialDelay = 0.5, repeatDelay = 0.1):FlxAnalogDirections1D<TAction>
+    {
+        return this.getRepeater(initialDelay, repeatDelay);
     }
 }
 
@@ -127,67 +138,35 @@ abstract FlxAnalogSet2DBase<TAction:EnumValue>(FlxAnalogSet<TAction>) to FlxAnal
      * Helper for extracting digital directional states from a 2D analog action.
      * It is similar to `justPressed` but holding the input for 0.5s will make it fire every 0.1s
      */
-    @:deprecated("holdRepeat is deprecated, use repeat(0.1, 0.5), instead")
+    @:deprecated("holdRepeat is deprecated, use waitAndRepeat(), instead")
     public var holdRepeat(get, never):FlxAnalogDirections2D<TAction>;
     inline function get_holdRepeat()
     {
-        return repeat(REPEAT_DELAY, INITIAL_DELAY);
+        return waitAndRepeat();
     }
     
     /**
-     * A repeating  event, similar to `justPressed` but holding the
-     * input for some `initial` time will make it fire every repeatedly.
-     * @param repeat   How often to repeat the event
-     * @param initial  How long until the second firing
+     * An event that fires when just pressed, then repeats at the given interval
+     * 
+     * @param   delay  How often to fire the event
      */
-    public function repeat(repeat = 0.1, initial = 0.0):FlxAnalogDirections2D<TAction>
+    inline public function repeat(delay = 0.1):FlxAnalogDirections2D<TAction>
     {
-        return this.getRepeater(repeat, initial);
+        return this.getRepeater(0, delay);
+    }
+    
+    /**
+     * An event that fires when just pressed, then repeats after the initial time
+     * 
+     * @param   initialDelay  How long after the initial press to start repeating
+     * @param   repeatDelay   How often to fire the event
+     */
+    inline public function waitAndRepeat(initialDelay = 0.5, repeatDelay = 0.1):FlxAnalogDirections2D<TAction>
+    {
+        return this.getRepeater(initialDelay, repeatDelay);
     }
 }
 
-inline var INITIAL_DELAY = 0.5;
-inline var REPEAT_DELAY = 0.1;
-
-@:forward
-private abstract FloatMap<T>(Map<Int, T>) from Map<Int, T>
-{
-    inline public function new () { this = []; }
-    
-    @:arrayAccess
-    inline public function set(key:Float, value:T)
-    {
-        this.set(toKey(key), value);
-    }
-    
-    @:arrayAccess
-    inline public function get(key:Float)
-    {
-        return this.get(toKey(key));
-    }
-    
-    inline public function exists(key:Float)
-    {
-        return this.exists(toKey(key));
-    }
-    
-    inline public function copy():FloatMap<T>
-    {
-        return this.copy();
-    }
-    
-	// public function toString():String {} // TODO:
-    
-    inline public function remove(key:Float)
-    {
-        return this.remove(toKey(key));
-    }
-    
-    static function toKey(f:Float):Int
-    {
-        return Math.round(f * 1000);
-    }
-}
 
 /**
  * Manages analog actions. There is usually only 1 of these per FlxControls instance, and it's only
@@ -197,11 +176,15 @@ private abstract FloatMap<T>(Map<Int, T>) from Map<Int, T>
 @:allow(flixel.addons.input.FlxAnalogSet2DBase)
 class FlxAnalogSet<TAction:EnumValue>
 {
+    #if (FLX_DEBUG && FlxControls.dev)
+    public var enableDebugWatchers = false;
+    #end
+    
     final pressed:FlxAnalogDirections2D<TAction>;
     final justPressed:FlxAnalogDirections2D<TAction>;
     final released:FlxAnalogDirections2D<TAction>;
     final justReleased:FlxAnalogDirections2D<TAction>;
-    final repeaters = new FloatMap<FloatMap<FlxAnalogDirections2D<TAction>>>();
+    final repeaters = new Map<DigitalEvent, FlxAnalogDirections2D<TAction>>();
     
     var upInput = new FlxRepeatInput<FlxDirection>(UP);
     var downInput = new FlxRepeatInput<FlxDirection>(DOWN);
@@ -225,17 +208,6 @@ class FlxAnalogSet<TAction:EnumValue>
         justReleased = new FlxAnalogDirections2D(this, (i)->i.hasState(JUST_RELEASED));
     }
     
-    #if (FLX_DEBUG && FlxControls.dev)
-    public function addDebugWatchers()
-    {
-        final id = name.split("-")[0].split(":").pop();
-        FlxG.watch.addFunction('$id-U', ()->   upInput.toString());
-        FlxG.watch.addFunction('$id-D', ()-> downInput.toString());
-        FlxG.watch.addFunction('$id-L', ()-> leftInput.toString());
-        FlxG.watch.addFunction('$id-R', ()->rightInput.toString());
-    }
-    #end
-    
     function destroy()
     {
         parent = null;
@@ -255,17 +227,26 @@ class FlxAnalogSet<TAction:EnumValue>
         downInput.updateWithState(control.y < 0);
         rightInput.updateWithState(control.x > 0);
         leftInput.updateWithState(control.x < 0);
+        
+        #if (FLX_DEBUG && FlxControls.dev)
+        if (enableDebugWatchers)
+        {
+            final id = name.split("-")[0].split(":").pop();
+            FlxG.watch.addQuick('$id-U',    upInput.toString());
+            FlxG.watch.addQuick('$id-D',  downInput.toString());
+            FlxG.watch.addQuick('$id-L',  leftInput.toString());
+            FlxG.watch.addQuick('$id-R', rightInput.toString());
+        }
+        #end
     }
     
-    function getRepeater(repeat:Float, initial:Float):FlxAnalogDirections2D<TAction>
+    function getRepeater(initial:Float, repeat:Float):FlxAnalogDirections2D<TAction>
     {
-        if (false == repeaters.exists(repeat))
-            repeaters[repeat] = new FloatMap<FlxAnalogDirections2D<TAction>>();
+        final event = REPEAT_CUSTOM(initial, repeat);
+        if (false == repeaters.exists(event))
+            repeaters[event] = new FlxAnalogDirections2D(this, (i)->i.triggerRepeat(initial, repeat));
         
-        if (false == repeaters[repeat].exists(initial))
-            repeaters[repeat][initial] = new FlxAnalogDirections2D(this, (i)->i.triggerRepeat(repeat, initial));
-        
-        return repeaters[repeat][initial];
+        return repeaters[event];
     }
     
     /**
@@ -502,19 +483,18 @@ class FlxControlAnalog extends FlxActionAnalog
         }
     }
     
-    inline function addGamepadInput(inputID:FlxGamepadInputID, axis, gamepadID:FlxDeviceID
-    )
+    inline function addGamepadInput(inputID:FlxGamepadInputID, axis, gamepadID:FlxDeviceID)
     {
-        add(new AnalogGamepadStick(inputID, this.trigger, axis, gamepadID.toDeviceID()));
+        add(new AnalogGamepad(inputID, this.trigger, axis, gamepadID));
     }
     
     function removeGamepadInput(inputID:FlxGamepadInputID, axis)
     {
         for (input in this.inputs)
         {
-            if (input is AnalogGamepadStick)
+            if (input is AnalogGamepad)
             {
-                final input:AnalogGamepadStick = cast input;
+                final input:AnalogGamepad = cast input;
                 if (input.inputID == inputID && input.axis == axis)
                 {
                     this.remove(input);
@@ -719,7 +699,7 @@ class FlxControlAnalog extends FlxActionAnalog
         for (input in this.inputs)
         {
             if (input.device == GAMEPAD)
-                input.deviceID = id.toDeviceID();
+                input.deviceID = id.toLegacy();
         }
     }
     
@@ -841,9 +821,9 @@ private class Analog2DKeys extends ActionInputAnalog
     }
 }
 
-inline function checkPad(id:FlxGamepadInputID, gamepadID:FlxDeviceID):Float
+inline function checkPad(id:FlxGamepadInputID, gamepadID:FlxInputDeviceID):Float
 {
-    return checkPadBool(id, gamepadID) ? 1.0 : 0.0;
+    return checkPadBool(id, FlxDeviceIDTools.fromLegacy(gamepadID)) ? 1.0 : 0.0;
 }
 
 function checkPadBool(id:FlxGamepadInputID, gamepadID:FlxDeviceID):Bool
@@ -851,15 +831,15 @@ function checkPadBool(id:FlxGamepadInputID, gamepadID:FlxDeviceID):Bool
     #if FLX_GAMEPAD
     return switch gamepadID
     {
-        case FlxDeviceIDRaw.ID(id):
+        case FlxDeviceID.ID(id):
             final gamepad = FlxG.gamepads.getByID(id);
             gamepad != null && gamepad.checkStatus(id, PRESSED);
-        case FlxDeviceIDRaw.FIRST_ACTIVE:
+        case FlxDeviceID.FIRST_ACTIVE:
             final gamepad = FlxG.gamepads.getFirstActiveGamepad();
             gamepad != null && gamepad.checkStatus(id, PRESSED);
-        case FlxDeviceIDRaw.ALL:
+        case FlxDeviceID.ALL:
             FlxG.gamepads.anyPressed(id);
-        case FlxDeviceIDRaw.NONE:
+        case FlxDeviceID.NONE:
             false;
     }
     #else
@@ -876,7 +856,7 @@ private class Analog1DGamepad extends ActionInputAnalog
     {
         this.up = up;
         this.down = down;
-        super(GAMEPAD, -1, trigger, X, gamepadID.toDeviceID());
+        super(GAMEPAD, -1, trigger, X, gamepadID.toLegacy());
     }
     
     override function update()
@@ -888,8 +868,109 @@ private class Analog1DGamepad extends ActionInputAnalog
     }
 }
 
-private class AnalogGamepadStick extends FlxActionInputAnalogGamepad
+private class AnalogGamepad extends FlxActionInputAnalog
 {
+    /**
+    * Gamepad action input for analog (trigger, joystick, touchpad, etc) events
+    * @param   inputID    "universal" gamepad input ID (LEFT_TRIGGER, RIGHT_ANALOG_STICK, TILT_PITCH, etc)
+    * @param   trigger    What state triggers this action (MOVED, JUST_MOVED, STOPPED, JUST_STOPPED)
+    * @param   axis       which axes to monitor for triggering: X, Y, EITHER, or BOTH
+    * @param   gamepadID  specific gamepad ID, or FlxInputDeviceID.FIRST_ACTIVE / ALL
+    */
+    public function new(inputID:FlxGamepadInputID, trigger, axis = FlxAnalogAxis.EITHER, gamepadID = FlxDeviceID.FIRST_ACTIVE)
+    {
+        super(FlxInputDevice.GAMEPAD, inputID, trigger, axis, gamepadID.toLegacy());
+        checkInputId(inputID);
+    }
+    
+    function checkInputId(inputID:FlxGamepadInputID)
+    {
+        switch (inputID)
+        {
+            case LEFT_ANALOG_STICK | RIGHT_ANALOG_STICK
+                | LEFT_TRIGGER | RIGHT_TRIGGER
+                | POINTER_X | POINTER_Y
+                | DPAD:
+            case found:
+                throw 'Unexpected inputID: $found';
+        }
+    }
+    
+    override public function update():Void
+    {
+        #if FLX_GAMEPAD
+        final numPads = FlxG.gamepads.numActiveGamepads;
+        switch FlxDeviceIDTools.fromLegacy(deviceID)
+        {
+            case ALL:
+                for (i in 0...numPads)
+                {
+                    if (pollGamepad(FlxG.gamepads.getByID(i)))
+                        break;
+                }
+            case FIRST_ACTIVE:
+                pollGamepadSafe(FlxG.gamepads.getFirstActiveGamepad());
+            case ID(id) if (numPads > id):
+                pollGamepadSafe(FlxG.gamepads.getByID(id));
+            case NONE | ID(_):
+                updateValues(0, 0);
+        }
+        #else
+        updateValues(0, 0);
+        #end
+    }
+    
+    #if FLX_GAMEPAD
+    function pollGamepadSafe(gamepad:Null<FlxGamepad>):Bool
+    {
+        if (gamepad != null)
+            return pollGamepad(gamepad);
+        
+        updateValues(0, 0);
+        return false;
+    }
+    
+    function pollGamepad(gamepad:FlxGamepad):Bool
+    {
+        inline function updateHelper(x:Float, y:Float):Bool
+        {
+            updateValues(x, y);
+            return x != 0 || y != 0;
+        }
+        
+        final values = gamepad.analog.value;
+        return switch (inputID:FlxGamepadInputID)
+        {
+            case FlxGamepadInputID.LEFT_ANALOG_STICK:
+                updateHelper(values.LEFT_STICK_X, values.LEFT_STICK_Y);
+                
+            case FlxGamepadInputID.RIGHT_ANALOG_STICK:
+                updateHelper(values.RIGHT_STICK_X, values.RIGHT_STICK_Y);
+                
+            case FlxGamepadInputID.LEFT_TRIGGER:
+                updateHelper(values.LEFT_TRIGGER, 0);
+            
+            case FlxGamepadInputID.RIGHT_TRIGGER:
+                updateHelper(values.RIGHT_TRIGGER, 0);
+
+            case FlxGamepadInputID.POINTER_X:
+                updateHelper(values.POINTER_X, 0);
+
+            case FlxGamepadInputID.POINTER_Y:
+                updateHelper(values.POINTER_Y, 0);
+
+            case FlxGamepadInputID.DPAD:
+                final pressed = gamepad.pressed;
+                updateHelper
+                    ( (pressed.DPAD_RIGHT ? 1 : 0) - (pressed.DPAD_LEFT ? 1 : 0)
+                    , (pressed.DPAD_DOWN  ? 1 : 0) - (pressed.DPAD_UP   ? 1 : 0)
+                    );
+            case found:
+                throw 'Unexpected inputID: $found';
+        }
+    }
+    #end
+    
     override function updateValues(x:Float, y:Float)
     {
         super.updateValues(x, -y);
@@ -910,7 +991,7 @@ private class Analog2DGamepad extends ActionInputAnalog
         this.right = right;
         this.left = left;
         
-        super(GAMEPAD, -1, trigger, EITHER, gamepadID.toDeviceID());
+        super(GAMEPAD, -1, trigger, EITHER, gamepadID.toLegacy());
     }
     
     override function update()

--- a/lib/flixel/addons/input/FlxAnalogSet.hx
+++ b/lib/flixel/addons/input/FlxAnalogSet.hx
@@ -484,16 +484,16 @@ class FlxControlAnalog extends FlxActionAnalog
     
     inline function addGamepadInput(inputID:FlxGamepadInputID, axis, gamepadID:FlxDeviceID)
     {
-        add(new AnalogGamepad(inputID, this.trigger, axis, gamepadID));
+        add(new ActionInputAnalogGamepad(inputID, this.trigger, axis, gamepadID));
     }
     
     function removeGamepadInput(inputID:FlxGamepadInputID, axis)
     {
         for (input in this.inputs)
         {
-            if (input is AnalogGamepad)
+            if (input is ActionInputAnalogGamepad)
             {
-                final input:AnalogGamepad = cast input;
+                final input:ActionInputAnalogGamepad = cast input;
                 if (input.inputID == inputID && input.axis == axis)
                 {
                     this.remove(input);
@@ -762,7 +762,7 @@ private class ActionInputAnalog extends FlxActionInputAnalog
     }
 }
 
-private class AnalogGamepad extends ActionInputAnalog
+private class ActionInputAnalogGamepad extends ActionInputAnalog
 {
     /**
     * Gamepad action input for analog (trigger, joystick, touchpad, etc) events

--- a/lib/flixel/addons/input/FlxDigitalSet.hx
+++ b/lib/flixel/addons/input/FlxDigitalSet.hx
@@ -112,9 +112,9 @@ class FlxDigitalSet<TAction:EnumValue>
 
 class FlxControlRepeatDigital extends FlxActionDigital
 {
-    public var input:Null<FlxRepeatInput<Int>>;
-    public final intitial:Float;
-    public final repeat:Float;
+    final input:Null<FlxRepeatInput<Int>>;
+    final intitial:Float;
+    final repeat:Float;
     
     public function new (name, intitial = 0.5, repeat = 0.1, ?callback)
     {
@@ -281,7 +281,7 @@ abstract FlxControlDigital(FlxActionDigital) to FlxActionDigital
     {
         if (this is FlxControlRepeatDigital)
         {
-            return Std.downcast(this, FlxControlRepeatDigital).input.toString();
+            return Std.downcast(this, FlxControlRepeatDigital).toString();
         }
         
         return Std.string(this.triggered);

--- a/lib/flixel/addons/input/FlxRepeatInput.hx
+++ b/lib/flixel/addons/input/FlxRepeatInput.hx
@@ -5,7 +5,7 @@ class FlxRepeatInput<T> extends flixel.input.FlxInput<T>
     var timer:Float = 0;
     var prevTimer:Float = 0;
     
-    public function triggerRepeat(repeat:Float, initial:Float):Bool
+    public function triggerRepeat(initial:Float, repeat:Float):Bool
     {
         return justPressed || (timer > initial && (timer % repeat) < (prevTimer % repeat));
     }

--- a/lib/flixel/addons/input/FlxRepeatInput.hx
+++ b/lib/flixel/addons/input/FlxRepeatInput.hx
@@ -2,41 +2,38 @@ package flixel.addons.input;
 
 class FlxRepeatInput<T> extends flixel.input.FlxInput<T>
 {
-    inline static var INITIAL_DELAY = 0.5;
-    inline static var REPEAT_DELAY = 0.1;
-    
     var timer:Float = 0;
-    var repeatTriggered = false;
+    var prevTimer:Float = 0;
     
-    public function triggerRepeat():Bool
+    public function triggerRepeat(repeat:Float, initial:Float):Bool
     {
-        return repeatTriggered;
+        return justPressed || (timer > initial && (timer % repeat) < (prevTimer % repeat));
     }
     
     public function updateWithState(isPressed:Bool)
     {
-        repeatTriggered = false;
         if (pressed)
         {
+            prevTimer = timer;
             timer += FlxG.elapsed;
-            repeatTriggered = timer >= REPEAT_DELAY;
-            if (repeatTriggered)
-                timer -= REPEAT_DELAY;
         }
         
         if (isPressed && released)
         {
             press();
-            timer = REPEAT_DELAY - INITIAL_DELAY;
-            repeatTriggered = true;
         }
         
         if (!isPressed && pressed)
         {
             release();
-            timer = 0;
+            prevTimer = timer = 0;
         }
         
         update();
+    }
+    
+    public function toString()
+    {
+        return '{ current:$current, timer: $timer }';
     }
 }

--- a/lib/flixel/addons/system/macros/FlxControlsMacro.hx
+++ b/lib/flixel/addons/system/macros/FlxControlsMacro.hx
@@ -136,6 +136,7 @@ class FlxControlsMacro
             public var justReleased(get, never):$digitalSetCT;
             
             /** Similar to `justPressed` but holding the input for 0.5s will make it fire every 0.1s */
+            @:deprecated("holdRepeat is deprecated, use waitAndRepeat() instead")
             public var holdRepeat  (get, never):$digitalSetCT;
             
             @:noCompletion inline function get_pressed     () { return cast digitalSets[flixel.addons.input.FlxControls.DigitalEvent.PRESSED      ]; }
@@ -143,6 +144,27 @@ class FlxControlsMacro
             @:noCompletion inline function get_justPressed () { return cast digitalSets[flixel.addons.input.FlxControls.DigitalEvent.JUST_PRESSED ]; }
             @:noCompletion inline function get_justReleased() { return cast digitalSets[flixel.addons.input.FlxControls.DigitalEvent.JUST_RELEASED]; }
             @:noCompletion inline function get_holdRepeat  () { return cast digitalSets[flixel.addons.input.FlxControls.DigitalEvent.REPEAT       ]; }
+            
+            /**
+             * An event that fires when just pressed, then repeats at the given interval
+             * 
+             * @param   delay  How often to fire the event
+             */
+            inline public function repeat(delay = 0.1):$digitalSetCT
+            {
+                return cast getRepeater(0.0, delay);
+            }
+            
+            /**
+             * An event that fires when just pressed, then repeats after the initial time
+             * 
+             * @param   initialDelay  How long after the initial press to start repeating
+             * @param   repeatDelay   How often to fire the event
+             */
+            inline public function waitAndRepeat(initialDelay = 0.5, repeatDelay = 0.1):$digitalSetCT
+            {
+                return cast getRepeater(initialDelay, repeatDelay);
+            }
         }).fields;
         
         /** Helper to concat without creating a new array */

--- a/samples/FlxCamera/source/PlayState.hx
+++ b/samples/FlxCamera/source/PlayState.hx
@@ -130,7 +130,9 @@ class PlayState extends FlxState
 		if (zoom.up  ) setZoom(.1);
 		if (zoom.down) setZoom(-.1);
 		
-		if (player.controls.justPressed.SHAKE) FlxG.camera.shake();
+		final repeatSet = player.controls.repeat(1.0);
+		if (repeatSet.check(SHAKE)) FlxG.camera.shake();
+		// if (repeatSet.SHAKE) FlxG.camera.shake();
 	}
 	
 	public function setZoom(delta:Float)

--- a/samples/FlxCamera/source/PlayState.hx
+++ b/samples/FlxCamera/source/PlayState.hx
@@ -104,6 +104,10 @@ class PlayState extends FlxState
 		FlxG.worldBounds.set(levelMinX, levelMinY, levelWidth, levelHeight);
 		FlxG.camera.follow(player, followStyles[0], 1);
 		deadzoneOverlay.redraw(FlxG.camera); // now that deadzone is present
+		
+		#if (FLX_DEBUG && FlxControls.dev)
+		player.controls.STYLE.addDebugWatchers();
+		#end
 	}
 	
 	override public function update(elapsed:Float):Void
@@ -112,10 +116,10 @@ class PlayState extends FlxState
 		
 		hud.updateInfo(player.controls);
 		
-		final style = player.controls.STYLE.holdRepeat;
-		final lerp = player.controls.LERP.holdRepeat;
-		final lead = player.controls.LEAD.holdRepeat;
-		final zoom = player.controls.ZOOM.holdRepeat;
+		final style = player.controls.STYLE.repeat(0.2);
+		final lerp = player.controls.LERP.repeat(0.2);
+		final lead = player.controls.LEAD.repeat(0.2);
+		final zoom = player.controls.ZOOM.repeat(0.2);
 		
 		if (style.up  ) setStyle(1);
 		if (style.down) setStyle(-1);

--- a/tests/coverage/.vscode/settings.json
+++ b/tests/coverage/.vscode/settings.json
@@ -15,9 +15,9 @@
 	],
 	"lime.buildTypes":
     [ { "label": "Final", "enabled":false }
-    , { "label": "Debug", "enabled":false }
-    , { "args": ["-Dcoverage1"], "label": "Coverage1" }
-    , { "args": ["-Dcoverage2"], "label": "Coverage2" }
-    , { "args": ["-Dcoverage3"], "label": "Coverage3" }
+    // , { "label": "Debug", "enabled":false }
+    // , { "args": ["-Dcoverage1"], "label": "Coverage1" }
+    // , { "args": ["-Dcoverage2"], "label": "Coverage2" }
+    // , { "args": ["-Dcoverage3"], "label": "Coverage3" }
 	]
 }

--- a/tests/coverage/source/Main.hx
+++ b/tests/coverage/source/Main.hx
@@ -15,8 +15,8 @@ class Main extends openfl.display.Sprite
     {
         super();
         
-        addChild(new flixel.FlxGame(0, 0, BootState2, 20, 20));
-        // addChild(new flixel.FlxGame(0, 0, BootState, 20, 20));
+        addChild(new flixel.FlxGame(0, 0, BootState, 20, 20));
+        // addChild(new flixel.FlxGame(0, 0, BootState2, 20, 20));
     }
 }
 
@@ -47,7 +47,7 @@ class BootState2 extends flixel.FlxState
         
         final repeatMove = controls.repeat(0.2);
         final repeatColor = controls.repeat(0.1);
-        final repeatMove = controls.MOVE.repeat(0.5);
+        // final repeatMove = controls.MOVE.repeat(0.5);
         final repeatScale = controls.MOVE.repeat(0.5);
         #if (FLX_DEBUG && FlxControls.dev)
         // repeatMove.enableDebugWatchers = true;

--- a/tests/coverage/source/Main.hx
+++ b/tests/coverage/source/Main.hx
@@ -1,10 +1,13 @@
 package ;
 
+import flixel.addons.input.FlxControls;
 import flixel.FlxG;
+import flixel.FlxSprite;
 import flixel.input.FlxInput;
 import flixel.input.keyboard.FlxKey;
 import flixel.ui.FlxVirtualPad;
 import input.Controls;
+import input.Controls2;
 
 class Main extends openfl.display.Sprite
 {
@@ -12,7 +15,66 @@ class Main extends openfl.display.Sprite
     {
         super();
         
-        addChild(new flixel.FlxGame(0, 0, BootState, 20, 20));
+        addChild(new flixel.FlxGame(0, 0, BootState2, 20, 20));
+        // addChild(new flixel.FlxGame(0, 0, BootState, 20, 20));
+    }
+}
+
+
+class BootState2 extends flixel.FlxState
+{
+    var controls:Controls2;
+    var sprite:FlxSprite;
+    
+    override function create()
+    {
+        controls = new Controls2("test");
+        #if (flixel < "5.9.0")
+        FlxG.inputs.add(controls);
+        #else
+        FlxG.inputs.addInput(controls);
+        #end
+        
+        controls.setGamepadID(FlxDeviceID.FIRST_ACTIVE);
+        
+        add(sprite = new FlxSprite(10, 10).makeGraphic(20, 20));
+        sprite.origin.set(0, 0);
+    }
+    
+    override function update(elapsed:Float)
+    {
+        super.update(elapsed);
+        
+        final repeatMove = controls.repeat(0.2);
+        final repeatColor = controls.repeat(0.1);
+        final repeatMove = controls.MOVE.repeat(0.5);
+        final repeatScale = controls.MOVE.repeat(0.5);
+        #if (FLX_DEBUG && FlxControls.dev)
+        // repeatMove.enableDebugWatchers = true;
+        // repeatColor.enableDebugWatchers = true;
+        controls.MOVE.enableDebugWatchers = true;
+        #end
+        
+        if (repeatMove.L) sprite.x -= sprite.width;
+        if (repeatMove.R) sprite.x += sprite.width;
+        if (repeatMove.U) sprite.y -= sprite.height;
+        if (repeatMove.D) sprite.y += sprite.height;
+        if (repeatColor.any([U,D,L,R])) sprite.color = sprite.color == 0xFFffffff ? 0xFFff0000 : 0xFFffffff;
+        
+        // if (repeatMove.left ) sprite.x -= sprite.width;
+        // if (repeatMove.right) sprite.x += sprite.width;
+        // if (repeatMove.up   ) sprite.y -= sprite.height;
+        // if (repeatMove.down ) sprite.y += sprite.height;
+        
+        if (repeatScale.left ) sprite.scale.x -= 1.0;
+        if (repeatScale.right) sprite.scale.x += 1.0;
+        if (repeatScale.up   ) sprite.scale.y -= 1.0;
+        if (repeatScale.down ) sprite.scale.y += 1.0;
+        
+        if (sprite.scale.x < 1) sprite.scale.x = 1;
+        if (sprite.scale.y < 1) sprite.scale.y = 1;
+        sprite.width = sprite.scale.x * sprite.frameWidth;
+        sprite.height = sprite.scale.y * sprite.frameHeight;
     }
 }
 
@@ -56,7 +118,7 @@ class BootState extends flixel.FlxState
         FlxG.watch.addFunction("down"  , ()->controls.pressed.DOWN  );
         FlxG.watch.addFunction("left"  , ()->controls.pressed.LEFT  );
         FlxG.watch.addFunction("right" , ()->controls.pressed.RIGHT );
-        FlxG.watch.addFunction("right-rp" , ()->controls.holdRepeat.RIGHT );
+        FlxG.watch.addFunction("right-rp" , ()->controls.waitAndRepeat(0.5, 0.1).RIGHT );
         
         FlxG.watch.addFunction("cam-up" , ()->{
             // trace(controls.CAM.pressed);
@@ -66,7 +128,7 @@ class BootState extends flixel.FlxState
         FlxG.watch.addFunction("cam-left" , ()->controls.CAM.pressed.left ); 
         FlxG.watch.addFunction("cam-right", ()->controls.CAM.pressed.right);
         FlxG.watch.addFunction("cam-up"   , ()->controls.CAM.pressed.up   );
-        FlxG.watch.addFunction("cam-right-rp", ()->controls.CAM.holdRepeat.right);
+        // FlxG.watch.addFunction("cam-right-rp", ()->controls.CAM.holdRepeat.right);
         
         // // Check if multiple actions are pressed like so:
         FlxG.watch.addFunction("l/r"   , ()->controls.pressed.any([LEFT, RIGHT]));

--- a/tests/coverage/source/input/Controls2.hx
+++ b/tests/coverage/source/input/Controls2.hx
@@ -1,0 +1,33 @@
+package input;
+
+import flixel.addons.input.FlxControls;
+import flixel.addons.input.FlxControlInputType;
+import flixel.addons.input.FlxControlInputType.FlxMouseInputType.Motion as MouseMove;
+import flixel.addons.input.FlxControlInputType.FlxMouseInputType.Motion as MouseDrag;
+import flixel.addons.input.FlxControlInputType.FlxKeyInputType.Multi as MultiKey;
+import flixel.addons.input.FlxControlInputType.FlxKeyInputType.Arrows as ArrowKeys;
+import flixel.addons.input.FlxControlInputType.FlxGamepadInputType.Multi as MultiPad;
+import flixel.addons.input.FlxControlInputType.FlxVirtualPadInputType.Multi as MultiVPad;
+import flixel.addons.input.FlxControlInputType.FlxVirtualPadInputType.Arrows as VPadArrows;
+import flixel.addons.input.FlxControlInputType.FlxVirtualPadInputID as VPad;
+import flixel.input.gamepad.FlxGamepadInputID as GPad;
+import flixel.input.keyboard.FlxKey as Key;
+
+/**
+ * A list of actions the user can perform via inputs.
+ * `@:analog` actions expect inputs like gamepad triggers, joysticks, and mice.
+ * `@:inputs` determines the default inputs mapped to this action (can be swapped at runtime)
+ */
+enum Action2
+{
+    // @:inputs([Key.W, GPad.DPAD_UP   , RIGHT_STICK_DIGITAL_UP   ]) U;
+    // @:inputs([Key.S, GPad.DPAD_DOWN , RIGHT_STICK_DIGITAL_DOWN ]) D;
+    // @:inputs([Key.A, GPad.DPAD_LEFT , RIGHT_STICK_DIGITAL_LEFT ]) L;
+    // @:inputs([Key.D, GPad.DPAD_RIGHT, RIGHT_STICK_DIGITAL_RIGHT]) R;
+    
+    // @:inputs([ArrowKeys, Face, LEFT_ANALOG_STICK])
+    @:inputs([ArrowKeys, Face, DPad, LEFT_ANALOG_STICK, RIGHT_ANALOG_STICK])
+    @:analog(x, y) MOVE;
+}
+
+class Controls2 extends FlxControls<Action2> {}

--- a/tests/coverage/source/input/Controls2.hx
+++ b/tests/coverage/source/input/Controls2.hx
@@ -20,13 +20,13 @@ import flixel.input.keyboard.FlxKey as Key;
  */
 enum Action2
 {
-    // @:inputs([Key.W, GPad.DPAD_UP   , RIGHT_STICK_DIGITAL_UP   ]) U;
-    // @:inputs([Key.S, GPad.DPAD_DOWN , RIGHT_STICK_DIGITAL_DOWN ]) D;
-    // @:inputs([Key.A, GPad.DPAD_LEFT , RIGHT_STICK_DIGITAL_LEFT ]) L;
-    // @:inputs([Key.D, GPad.DPAD_RIGHT, RIGHT_STICK_DIGITAL_RIGHT]) R;
+    @:inputs([Key.W, GPad.DPAD_UP   , RIGHT_STICK_DIGITAL_UP   ]) U;
+    @:inputs([Key.S, GPad.DPAD_DOWN , RIGHT_STICK_DIGITAL_DOWN ]) D;
+    @:inputs([Key.A, GPad.DPAD_LEFT , RIGHT_STICK_DIGITAL_LEFT ]) L;
+    @:inputs([Key.D, GPad.DPAD_RIGHT, RIGHT_STICK_DIGITAL_RIGHT]) R;
     
-    // @:inputs([ArrowKeys, Face, LEFT_ANALOG_STICK])
-    @:inputs([ArrowKeys, Face, DPad, LEFT_ANALOG_STICK, RIGHT_ANALOG_STICK])
+    @:inputs([ArrowKeys, Face, LEFT_ANALOG_STICK])
+    // @:inputs([ArrowKeys, Face, DPad, LEFT_ANALOG_STICK, RIGHT_ANALOG_STICK])
     @:analog(x, y) MOVE;
 }
 


### PR DESCRIPTION
Fixes #8

Adds `repeat` and `waitAndRepeat` to `FlxControls` and `FlxAnalogSet`

## Examples
- `controls.repeat(0.1).SHOOT`: Always true when shoot is just pressed, otherwise true every 0.1s when held
- `controls.waitAndRepeat(0.5, 0.1).SHOOT`: Always true when shoot is just pressed, otherwise true every 0.1s after being held for 0.5s
- `controls.MOVE.repeat(0.1).right`: Always true when just moved to the right, otherwise true every 0.1s when held
- `controls.MOVE.waitAndRepeat(0.5, 0.1).right`: Always true just moved to the right, otherwise true every 0.1s after being held for 0.5s

## Misc
fixed a bug where FlxDeviceID.ALL analog sticks apparently never worked because of FlxActions ignoring it