### PR TITLE
Improve repeaters equation

### DIFF
--- a/lib/flixel/addons/input/FlxRepeatInput.hx
+++ b/lib/flixel/addons/input/FlxRepeatInput.hx
@@ -7,7 +7,10 @@ class FlxRepeatInput<T> extends flixel.input.FlxInput<T>
     
     public function triggerRepeat(initial:Float, repeat:Float):Bool
     {
-        return justPressed || (timer > initial && (timer % repeat) < (prevTimer % repeat));
+        inline function num(time:Float)
+            return Math.floor((time - initial) / repeat);
+
+	    return justPressed || (timer > initial && num(timer) > num(prevTimer));
     }
     
     public function updateWithState(isPressed:Bool)


### PR DESCRIPTION
Untested in demos, equation was tested in try.haxe:
```hx
function main() {
	testBoth(0.45, 0.1, 0.5, 0.1, true); // new: true != old: FALSE, expected: true
	testBoth(0.55, 0.1, 0.5, 0.1, true); // new: true == old: true, expected: true
	testBoth(0.55, 0.14, 0.5, 0.1, true); // new: true != old: FALSE, expected: true
	testBoth(0.0, 0.1, 0.5, 0.1, false); // new: false == old: false, expected: false
}

function testBoth(prevTime, delta, initial, repeat, expectation:Bool)
{
  final newResult = testRepeat(prevTime, delta, initial, repeat);
  final oldResult = testRepeat_old(prevTime, delta, initial, repeat);
  final eq = newResult == oldResult ? "==" : "!=";
  function boolStr(value:Bool) return getBoolStr(value, expectation);
  trace('new: ${boolStr(newResult)} $eq old: ${boolStr(oldResult)},'
    	+ ' expected: $expectation');
}

function getBoolStr(value:Bool, expected:Bool)
{
	return value == expected ? '$value' : '$value'.toUpperCase();
}

function testRepeat(prevTime:Float, delta:Float, initial:Float, repeat:Float) {
	inline function num(time:Float)
  {
  	return Math.floor((time - initial) / repeat);
  }

	return prevTime + delta > initial && num(prevTime + delta) > num(prevTime);
}

function testRepeat_old(prevTime:Float, delta:Float, initial:Float, repeat:Float)
{
  final timer = prevTime + delta;
	return (timer > initial
		&& (timer % repeat) < (prevTime % repeat));
}
```